### PR TITLE
Fix v1597 Event store pathing

### DIFF
--- a/Start.ahk
+++ b/Start.ahk
@@ -1157,13 +1157,31 @@ BuyEvent(){
     Sleep(200)
     Click
     Sleep(1500)
+
+    ; Move down from gear shop as there is a new tree in the way.
+    Send("{s Down}")
+    HyperSleep(1200)
+    Send("{s Up}")
+
     Send("{" Dkey " down}")
-    HyperSleep(9500)
+    HyperSleep(10000)
     Send("{" Dkey " up}")
     Sleep(500)
     Send("{" Wkey " down}")
-    HyperSleep(300)
+
+    HyperSleep(1500)
     Send("{" Wkey " up}")
+
+    Sleep(500)
+    Send("{" Dkey " down}")
+    HyperSleep(500)
+    Send("{" Dkey " up}")
+
+    Sleep(500)
+    Send("{" WKey " down}")
+    HyperSleep(100)
+    Send("{" WKey " up}")
+
     Sleep(1500)
     Send("{" Ekey "}")
     clickOption(1,5)
@@ -1174,7 +1192,6 @@ BuyEvent(){
     CloseClutter()
     return 1
 }
-
 
 
 

--- a/scripts/gui.ahk
+++ b/scripts/gui.ahk
@@ -1,7 +1,7 @@
 
 #Requires AutoHotkey v2.0
 
-version := "v1.1.0"
+version := "v1.1.1"
 settingsFile := "settings.ini"
 
 


### PR DESCRIPTION
Fixes the pathing for the new event shop update. This adjusts the macro to move to the new position of the shop